### PR TITLE
Use live item in AugmentModal and bump UI version

### DIFF
--- a/GearSwapBuilder/gearswap-ui/index.html
+++ b/GearSwapBuilder/gearswap-ui/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>gearswap-ui</title>
+    <title>GearSwap Studio</title>
   </head>
   <body>
     <div id="root"></div>

--- a/GearSwapBuilder/gearswap-ui/package.json
+++ b/GearSwapBuilder/gearswap-ui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gearswap-ui",
   "private": true,
-  "version": "1.0.2",
+  "version": "1.2.0",
   "description": "A classic FFXI-style GearSwap set builder",
   "author": "Quishwar",
   "type": "module",

--- a/GearSwapBuilder/gearswap-ui/src/App.tsx
+++ b/GearSwapBuilder/gearswap-ui/src/App.tsx
@@ -14,7 +14,8 @@ export default function App() {
     isAugmentModalOpen,
     closeAugmentModal,
     modalTarget,
-    updateSlot
+    updateSlot,
+    allSets
   } = useGearStore();
 
   useEffect(() => {
@@ -64,15 +65,31 @@ export default function App() {
           <LuaPreview />
         </aside>
       </div>
+      {
+        (() => {
+          if (!modalTarget) return null;
 
-      {modalTarget && (
-        <AugmentModal
-          item={modalTarget.item}
-          isOpen={isAugmentModalOpen}
-          onOpenChange={closeAugmentModal}
-          onUpdate={(newData) => updateSlot(modalTarget.setName, modalTarget.slot, newData)}
-        />
-      )}
-    </div>
+          // Get the "live" item from the store so that updates (add/remove augments)
+          // are reflected immediately without closing/reopening the modal.
+          // We also handle the case where the slot might have been cleared or changed.
+          const currentItemData = allSets[modalTarget.setName]?.[modalTarget.slot];
+
+          // If the item was removed from the set while modal was open, fallback or close
+          // For now, we'll try to maintain valid object structure
+          const liveItem = typeof currentItemData === 'string'
+            ? { name: currentItemData }
+            : (currentItemData || modalTarget.item);
+
+          return (
+            <AugmentModal
+              item={liveItem}
+              isOpen={isAugmentModalOpen}
+              onOpenChange={closeAugmentModal}
+              onUpdate={(newData) => updateSlot(modalTarget.setName, modalTarget.slot, newData)}
+            />
+          );
+        })()
+      }
+    </div >
   );
 }


### PR DESCRIPTION
Update UI title to 'GearSwap Studio' and bump package version to 1.2.0. Refactor App.tsx to render AugmentModal with a live item pulled from the store (allSets) so augment additions/removals are reflected immediately while the modal is open; handle cases where the slot was cleared or changed by falling back to sensible item shapes. Minor cleanup to modal rendering to avoid stale data.